### PR TITLE
Use PORT variable in Dockerfile CMD

### DIFF
--- a/instagram-reel-downloader/Dockerfile
+++ b/instagram-reel-downloader/Dockerfile
@@ -24,4 +24,4 @@ EXPOSE 8080
 # -w 4: 4 worker processes
 # -b 0.0.0.0:$PORT: bind to all network interfaces on the specified port
 # --timeout 300: 5-minute timeout for workers
-CMD ["gunicorn", "-w", "2", "--timeout", "300", "-b", "0.0.0.0:8080", "app:app"]
+CMD ["gunicorn", "-w", "2", "--timeout", "300", "-b", "0.0.0.0:${PORT}", "app:app"]


### PR DESCRIPTION
## Summary
- use PORT env variable when starting gunicorn

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_688b77208f988323b15dc51f0ff7b7c4